### PR TITLE
no inference bug fix

### DIFF
--- a/app/const.py
+++ b/app/const.py
@@ -57,11 +57,26 @@ FEATURES_LIST = [
     "hour",
     "day",
 ]
-COLUMNS_TO_CATEGORIZE = [
+FEATURES_TYPE_MAP = {
+    "product": "str",
+    "campaign_id": "float64",
+    "product_category_1": "float64",
+    "product_category_2": "float64",
+    "gender": "float64",
+    "age_level": "float64",
+    "user_depth": "float64",
+    "city_development_index": "float64",
+    "var_1": "float64",
+    "hour": "float64",
+    "day": "float64",
+}
+CATEGORICAL_FEATURES_CATBOOST = [
     "product",
     "campaign_id",
     "product_category_1",
     "product_category_2",
+    # "gender",
+    # "var_1",
 ]
 TARGET_COLUMN = "is_click"
 PREDICTED_COLUMN = TARGET_COLUMN + "_predicted"
@@ -76,11 +91,11 @@ WANDB_PROJECT = "pre-main"
 # https://catboost.ai/docs/en/references/training-parameters/common
 MODEL_GS_PARAM_GRID = {
     "num_leaves": [31],
-    "iterations": [1000],
-    "learning_rate": np.logspace(np.log10(0.0001), np.log10(0.5), 5),
+    "iterations": [500],
+    "learning_rate": [0.01],
     "eval_metric": ["F1"],
-    "depth": [6, 10, 16], #np.arange(4, 11, 2),
-    "l2_leaf_reg": np.linspace(0, 5, 3),
+    "depth": [11],  # np.arange(4, 11, 2),
+    "l2_leaf_reg": [3],
     "nan_mode": ["Min"],
     "early_stopping_rounds": [10],
     "loss_function": ["Logloss"],

--- a/predict.py
+++ b/predict.py
@@ -12,8 +12,9 @@ from app.const import (
     RESULTS_FOLDER,
     PREDICTED_COLUMN,
     TARGET_COLUMN,
-    COLUMNS_TO_CATEGORIZE,
-    WANDB_PROJECT
+    WANDB_PROJECT,
+    FEATURES_TYPE_MAP,
+    CATEGORICAL_FEATURES_CATBOOST,
 )
 
 
@@ -53,14 +54,15 @@ def extract_features(df: pd.DataFrame) -> np.ndarray:
     print("Extracting features...")
     X = df[FEATURES_LIST]
     # Should be done during preprocessing
-    X[COLUMNS_TO_CATEGORIZE] = X[COLUMNS_TO_CATEGORIZE].astype(str)
+    # cat_features must be integer or string, real number values and NaN values should be converted to string.
+    X[CATEGORICAL_FEATURES_CATBOOST] = X[CATEGORICAL_FEATURES_CATBOOST].astype(str)
     print("Features extracted.")
     return X
 
 
 def load_data(path: str) -> pd.DataFrame:
     print(f"Loading data from {path}...")
-    df = pd.read_csv(path)
+    df = pd.read_csv(path, dtype=FEATURES_TYPE_MAP)
     print(df.info())
     print("Data loaded.")
     return df
@@ -94,8 +96,10 @@ if __name__ == "__main__":
     api = wandb.Api()
     runs = api.runs(f"Y-DATA-Ninjas/{WANDB_PROJECT}")
     runs_list = list(runs)  # Convert to a list
-    last_run = runs_list[-1] 
-    run = wandb.init(entity="Y-DATA-Ninjas", project=WANDB_PROJECT, id=last_run.id, resume="must")
+    last_run = runs_list[-1]
+    run = wandb.init(
+        entity="Y-DATA-Ninjas", project=WANDB_PROJECT, id=last_run.id, resume="must"
+    )
     run.log({"predictions_array": predictions.tolist()})
 
     if args.predictions_file_name is not None:
@@ -108,7 +112,7 @@ if __name__ == "__main__":
         out_path = os.path.join(
             RESULTS_FOLDER,
             # Commented out because throws an error y.f.
-            f"predictions_{input_file_name_without_extension}_{pd.Timestamp.now().strftime('%Y%m%d_%H%M%S')}.csv"
+            f"predictions_{input_file_name_without_extension}_{pd.Timestamp.now().strftime('%Y%m%d_%H%M%S')}.csv",
         )
 
     save_predictions(

--- a/preprocess.py
+++ b/preprocess.py
@@ -19,7 +19,6 @@ from app.const import (
     TARGET_COLUMN,
     DEFAULT_CSV_INFERENCE_PATH,
     WANDB_PROJECT,
-    COLUMNS_TO_CATEGORIZE
 )
 
 
@@ -39,8 +38,13 @@ def impute(df: pd.DataFrame) -> pd.DataFrame:
     for i in range(1, 13):
         gender = i < 7  # convert user group to gender
         age = (i % 7) + (1 - gender)  # convert user group to age
-        df_impute.loc[(df_impute["user_group_id"] == i) & df_impute["gender"].isna(), "gender"] = gender
-        df_impute.loc[(df_impute["user_group_id"] == i) & df_impute["age_level"].isna(), "age_level"] = age
+        df_impute.loc[
+            (df_impute["user_group_id"] == i) & df_impute["gender"].isna(), "gender"
+        ] = gender
+        df_impute.loc[
+            (df_impute["user_group_id"] == i) & df_impute["age_level"].isna(),
+            "age_level",
+        ] = age
 
     ###Impute missing values for campaign id
     web_campaign_dict = {
@@ -72,13 +76,8 @@ def preprocess(df: pd.DataFrame) -> pd.DataFrame:
     df_imputed["hour"] = df_imputed["dt"].dt.hour
     df_imputed["day"] = df_imputed["dt"].dt.day
 
-    # Make sure object columns are objects
-    # product already a categorical
-    for col in COLUMNS_TO_CATEGORIZE:
-        if df_imputed[col].dtype != 'object':
-            df_imputed[col] = df_imputed[col].astype('Int64')
-        # ensure column remains a string after saved and reloaded:
-        #df_imputed[col] = df_imputed[col].apply(lambda x: x + "s")
+    # ensure column remains a string after saved and reloaded:
+    # df_imputed[col] = df_imputed[col].apply(lambda x: x + "s")
 
     # Binarize var_1
     df_imputed["var_1"] = df_imputed["var_1"].astype(bool)

--- a/train.py
+++ b/train.py
@@ -14,7 +14,8 @@ from app.const import (
     MODELS_FOLDER,
     DEFAULT_MODEL_PATH,
     WANDB_PROJECT,
-    COLUMNS_TO_CATEGORIZE,
+    CATEGORICAL_FEATURES_CATBOOST,
+    FEATURES_TYPE_MAP,
 )
 
 
@@ -41,7 +42,8 @@ def prepare_data(df: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray]:
     print("Preparing data...")
     print("Extracting features...")
     X = df[FEATURES_LIST]
-    X[COLUMNS_TO_CATEGORIZE] = X[COLUMNS_TO_CATEGORIZE].astype(str)
+    # cat_features must be integer or string, real number values and NaN values should be converted to string.
+    X[CATEGORICAL_FEATURES_CATBOOST] = X[CATEGORICAL_FEATURES_CATBOOST].astype(str)
     print("Features extracted.")
     print("Extracting target...")
     y = df[TARGET_COLUMN]
@@ -52,7 +54,7 @@ def prepare_data(df: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray]:
 
 def load_data(path: str) -> pd.DataFrame:
     print(f"Loading data from {path}...")
-    df = pd.read_csv(path)
+    df = pd.read_csv(path, dtype=FEATURES_TYPE_MAP)
     print(df.info())
     print("Data loaded.")
     return df
@@ -150,7 +152,7 @@ if __name__ == "__main__":
     run.log(hyperparams)
 
     # Train model
-    model = fit_model(model, X_train, y_train, COLUMNS_TO_CATEGORIZE)
+    model = fit_model(model, X_train, y_train, CATEGORICAL_FEATURES_CATBOOST)
 
     # Save model
     save_model(model)


### PR DESCRIPTION
Yacov found the bug and the solution. Ophir will continue

Change log:
1. app/const.py:
    - Defined FEATURES_TYPE_MAP
    - Defined CATEGORICAL_FEATURES_CATBOOST
    - Deleted COLUMNS_TO_CATEGORIZE
2. predict.py:
    - Used pd.read_csv(path, dtype=FEATURES_TYPE_MAP) in load_data
    - Used X[CATEGORICAL_FEATURES_CATBOOST].astype(str) in extract_features
    - Deleted lines that use COLUMNS_TO_CATEGORIZE
3. preprocess.py:
    - Deleted lines that use COLUMNS_TO_CATEGORIZE 
4. train.py:
    - Used pd.read_csv(path, dtype=FEATURES_TYPE_MAP) in load_data
    - Used X[CATEGORICAL_FEATURES_CATBOOST].astype(str) in prepare_data
    - Used model = fit_model(model, X_train, y_train, CATEGORICAL_FEATURES_CATBOOST) in main
    - Deleted lines that use COLUMNS_TO_CATEGORIZE

Achieved an F1 score of 0.1547 on raw inference when trained on the whole raw train dataset with the following hyper-parameters:

MODEL_GS_PARAM_GRID = {
    "num_leaves": [31],
    "iterations": [500],
    "learning_rate": [0.01],
    "eval_metric": ["F1"],
    "depth": [11],  # np.arange(4, 11, 2),
    "l2_leaf_reg": [3],
    "nan_mode": ["Min"],
    "early_stopping_rounds": [10],
    "loss_function": ["Logloss"],
    "class_weights": ["Balanced"],  # ["Default", "Balanced"],
}

and when 

CATEGORICAL_FEATURES_CATBOOST = [
    "product",
    "campaign_id",
    "product_category_1",
    "product_category_2",
    # "gender",
    # "var_1",
]