### PR TITLE
Tasks upgrade

### DIFF
--- a/app/const.py
+++ b/app/const.py
@@ -37,6 +37,9 @@ DEFAULT_CSV_PREDICTIONS_INFERENCE_PATH = os.path.join(
     RESULTS_FOLDER, CSV_PREDICTIONS_INFERENCE_FILENAME
 )
 
+DEFAULT_ARCHIVE_EXPERIMENT = False
+DEFAULT_PREDICT_INFERENCE = False
+
 DEFAULT_REMOVE_DUPLICATES = True
 DEFAULT_REMOVE_MISSING_TARGET = True
 DEFAULT_MAKE_INFERENCE = False
@@ -101,9 +104,25 @@ MODEL_GS_PARAM_GRID = {
     "loss_function": ["Logloss"],
     "class_weights": ["Balanced"],  # ["Default", "Balanced"],
 }
+RANDOM_STATE_LIST = [DEFAULT_RANDOM_STATE]
 
-REVENUE_COST_DICT  = {'revenue': 2, 'cost': 0.02}
+FINAL_MODEL_PARAM = {
+    "num_leaves": 31,
+    "iterations": 500,
+    "learning_rate": 0.01,
+    "eval_metric": "F1",
+    "depth": 11,  # np.arange(4, 11, 2),
+    "l2_leaf_reg": 3,
+    "nan_mode": "Min",
+    "early_stopping_rounds": 10,
+    "loss_function": "Logloss",
+    "class_weights": "Balanced",  # ["Default", "Balanced"],
+}
+
+REVENUE_COST_DICT = {"revenue": 2, "cost": 0.02}
 
 STREAMLIT_OUTPUT_FILE_NAME_PREFIX = "predictions"
 STREAMLIT_INPUT_FILE_NAME_PREFIX = "raw_inference"
 STREAMLIT_PREPROCESSED_FILE_NAME_PREFIX = "inference"
+
+COMPUTE_METRICS_DEFAULT_THR = 0.5

--- a/tasks.py
+++ b/tasks.py
@@ -33,11 +33,6 @@ from app.const import (
 from app.utils import str2bool
 
 
-def prepare_data_for_pipeline():
-    print("Preparing data for pipeline...")
-    # put the data in central location
-
-
 @task(optional=["archive_experiment", "predict_inference"])
 def pipeline(
     c,
@@ -62,14 +57,12 @@ def pipeline(
         # Delete the last experiment
         c.run("inv clear-experiment")
 
-    # prepare_data_for_pipeline()
-
     # Get all experiment's hyperparameters (the parameters and their corresponding value lists)
     keys = MODEL_GS_PARAM_GRID.keys()
     values = MODEL_GS_PARAM_GRID.values()
 
     # Generate all combinations
-    combinations = itertools.product(*values)
+    combinations = list(itertools.product(*values))
 
     print("Running experiments...")
 
@@ -180,7 +173,7 @@ def train_all_train(
     # Create a group id that will be shared within the same run
     wandb_group_id = "experiment-" + wandb.util.generate_id()
 
-    print(f"Running experiment {idx}: {wandb_group_id}...")
+    print(f"Running experiment: {wandb_group_id}...")
 
     param_combination = FINAL_MODEL_PARAM
 
@@ -252,7 +245,7 @@ def predict_inference(c):
 
 @task(optional=["thr"])
 def compute_metrics(
-    y_true_file_path, y_pred_file_path, thr=COMPUTE_METRICS_DEFAULT_THR
+    c, y_true_file_path, y_pred_file_path, thr=COMPUTE_METRICS_DEFAULT_THR
 ):
 
     y_true = pd.read_csv(y_true_file_path, names=["is_click"])

--- a/tasks.py
+++ b/tasks.py
@@ -1,4 +1,7 @@
 import itertools
+import pandas as pd
+from sklearn.metrics import f1_score
+from sklearn.metrics import precision_recall_curve, auc
 from invoke import task
 from datetime import datetime
 import os
@@ -21,7 +24,13 @@ from app.const import (
     CSV_RAW_TRAIN_FILENAME,
     CSV_RAW_INFERENCE_FILENAME,
     MODEL_GS_PARAM_GRID,
+    DEFAULT_ARCHIVE_EXPERIMENT,
+    DEFAULT_PREDICT_INFERENCE,
+    RANDOM_STATE_LIST,
+    FINAL_MODEL_PARAM,
+    COMPUTE_METRICS_DEFAULT_THR,
 )
+from app.utils import str2bool
 
 
 def prepare_data_for_pipeline():
@@ -29,16 +38,29 @@ def prepare_data_for_pipeline():
     # put the data in central location
 
 
-@task
-def pipeline(c):
+@task(optional=["archive_experiment", "predict_inference"])
+def pipeline(
+    c,
+    archive_experiment=DEFAULT_ARCHIVE_EXPERIMENT,
+    predict_inference=DEFAULT_PREDICT_INFERENCE,
+):
 
     print("Running pipeline...")
+
+    # Validate flags input
+    archive_experiment = str2bool(archive_experiment)
+    predict_inference = str2bool(predict_inference)
 
     # Loading .env environment variables
     load_dotenv()
 
-    # Archive the last experiment
-    c.run("inv archive-experiment")
+    # Archive/delete last experiment
+    if archive_experiment:
+        # Archive the last experiment
+        c.run("inv archive-experiment")
+    else:
+        # Delete the last experiment
+        c.run("inv clear-experiment")
 
     # prepare_data_for_pipeline()
 
@@ -51,54 +73,137 @@ def pipeline(c):
 
     print("Running experiments...")
 
-    # Iterate over combinations and create a list/tuple of keys and current values
-    for idx, combination in enumerate(combinations):
+    # Iterate over all random states
+    for random_state in RANDOM_STATE_LIST:
 
-        # Create a group id that will be shared within the same run
-        wandb_group_id = "experiment-" + wandb.util.generate_id()
+        # Iterate over combinations and create a list/tuple of keys and current values
+        for idx, combination in enumerate(combinations):
 
-        print(f"Running experiment {idx}: {wandb_group_id}...")
+            # Create a group id that will be shared within the same run
+            wandb_group_id = "experiment-" + wandb.util.generate_id()
 
-        # Get the current combination of parameters
-        param_combination = dict(zip(keys, combination))
-        print(f"Experiment parameters: {param_combination}")
+            print(f"Running experiment {idx}: {wandb_group_id}...")
 
-        # Create a formatted string with the parameters
-        formatted_str = " ".join(
-            [
-                f"--{key.replace('_', '-')} {value}"
-                for key, value in param_combination.items()
-            ]
-        )
+            # Get the current combination of parameters
+            param_combination = dict(zip(keys, combination))
+            print(
+                f"Experiment parameters: 'random_state': {random_state}, {param_combination}"
+            )
 
-        # If this is the first experiment, preprocess the raw data
-        if idx == 0:
-            # preprocess raw train data
-            c.run(f"python preprocess.py --wandb-group-id {wandb_group_id}")
+            # Create a formatted string with the parameters
+            formatted_str = " ".join(
+                [
+                    f"--{key.replace('_', '-')} {value}"
+                    for key, value in param_combination.items()
+                ]
+            )
 
-        # train
-        c.run(f"python train.py --wandb-group-id {wandb_group_id} {formatted_str}")
+            # If this is the first experiment, preprocess the raw data
+            if idx == 0:
+                # preprocess raw train data
+                c.run(
+                    f"python preprocess.py --wandb-group-id {wandb_group_id} --random-state {random_state}"
+                )
 
-        # # predict on train
-        # c.run(
-        #     f"python predict.py --wandb-group-id {wandb_group_id} --input-data-path {DEFAULT_CSV_TRAIN_PATH} --predictions-file-name {CSV_PREDICTIONS_TRAIN_FILENAME}"
-        # )
+            # train
+            c.run(f"python train.py --wandb-group-id {wandb_group_id} {formatted_str}")
 
-        # # process train results
-        # c.run(
-        #     f"python results.py --wandb-group-id {wandb_group_id} --input-data-path {DEFAULT_CSV_PREDICTIONS_TRAIN_PATH}"
-        # )
+            # # predict on train
+            # c.run(
+            #     f"python predict.py --wandb-group-id {wandb_group_id} --input-data-path {DEFAULT_CSV_TRAIN_PATH} --predictions-file-name {CSV_PREDICTIONS_TRAIN_FILENAME}"
+            # )
 
-        # predict on test
-        c.run(
-            f"python predict.py --wandb-group-id {wandb_group_id} --input-data-path {DEFAULT_CSV_TEST_PATH} --predictions-file-name {CSV_PREDICTIONS_TEST_FILENAME}"
-        )
+            # # process train results
+            # c.run(
+            #     f"python results.py --wandb-group-id {wandb_group_id} --input-data-path {DEFAULT_CSV_PREDICTIONS_TRAIN_PATH}"
+            # )
 
-        # process test results
-        c.run(
-            f"python results.py --wandb-group-id {wandb_group_id} --input-data-path {DEFAULT_CSV_PREDICTIONS_TEST_PATH}"
-        )
+            # predict on test
+            c.run(
+                f"python predict.py --wandb-group-id {wandb_group_id} --input-data-path {DEFAULT_CSV_TEST_PATH} --predictions-file-name {CSV_PREDICTIONS_TEST_FILENAME}"
+            )
 
+            # process test results
+            c.run(
+                f"python results.py --wandb-group-id {wandb_group_id} --input-data-path {DEFAULT_CSV_PREDICTIONS_TEST_PATH}"
+            )
+
+            # Check if to predict on inference as well
+            if predict_inference:
+                # preprocess inference data
+                c.run(
+                    f"python preprocess.py --wandb-group-id {wandb_group_id} --inference-run True --csv-raw-path {DEFAULT_CSV_RAW_INFERENCE_PATH}"
+                )
+
+                # predict on inference
+                c.run(
+                    f"python predict.py --wandb-group-id {wandb_group_id} --input-data-path {DEFAULT_CSV_INFERENCE_PATH} --predictions-only True --predictions-file-name {CSV_PREDICTIONS_INFERENCE_FILENAME}"
+                )
+
+            print("Experiment finished.")
+
+            if archive_experiment:
+                c.run(
+                    f"inv archive-experiment --name {wandb_group_id} --leave-data True"
+                )
+            else:
+                c.run(f"inv clear-experiment --name {wandb_group_id} --leave-data True")
+
+    print("All experiments finished.")
+
+    print("Pipeline finished.")
+
+
+@task(optional=["archive_experiment", "predict_inference"])
+def train_all_train(
+    c,
+    archive_experiment=True,
+    predict_inference=True,
+):
+    print("Running train on all raw train...")
+
+    # Validate flags input
+    archive_experiment = str2bool(archive_experiment)
+    predict_inference = str2bool(predict_inference)
+
+    # Loading .env environment variables
+    load_dotenv()
+
+    # Archive/delete last experiment
+    if archive_experiment:
+        # Archive the last experiment
+        c.run("inv archive-experiment")
+    else:
+        # Delete the last experiment
+        c.run("inv clear-experiment")
+
+    # Create a group id that will be shared within the same run
+    wandb_group_id = "experiment-" + wandb.util.generate_id()
+
+    print(f"Running experiment {idx}: {wandb_group_id}...")
+
+    param_combination = FINAL_MODEL_PARAM
+
+    print(f"Experiment parameters: {param_combination}")
+
+    # Create a formatted string with the parameters
+    formatted_str = " ".join(
+        [
+            f"--{key.replace('_', '-')} {value}"
+            for key, value in param_combination.items()
+        ]
+    )
+
+    # preprocess raw train data without train-test split
+    c.run(
+        f"python preprocess.py --wandb-group-id {wandb_group_id} --test-train-split False"
+    )
+
+    # train
+    c.run(f"python train.py --wandb-group-id {wandb_group_id} {formatted_str}")
+
+    # Check if to predict on inference as well
+    if predict_inference:
         # preprocess inference data
         c.run(
             f"python preprocess.py --wandb-group-id {wandb_group_id} --inference-run True --csv-raw-path {DEFAULT_CSV_RAW_INFERENCE_PATH}"
@@ -109,13 +214,55 @@ def pipeline(c):
             f"python predict.py --wandb-group-id {wandb_group_id} --input-data-path {DEFAULT_CSV_INFERENCE_PATH} --predictions-only True --predictions-file-name {CSV_PREDICTIONS_INFERENCE_FILENAME}"
         )
 
-        print("Experiment finished.")
+    if archive_experiment:
+        c.run(f"inv archive-experiment --name {wandb_group_id}")
 
-        c.run(f"inv archive-experiment --name {wandb_group_id} --leave-data True")
+    print("Train on all raw train finished.")
 
-    print("All experiments finished.")
 
-    print("Pipeline finished.")
+@task
+def predict_inference(c):
+
+    print("Running predict inference...")
+
+    # Validate there is a model file in the models folder
+    if not os.path.isdir("models"):
+        raise ValueError("Models folder does not exist.")
+    else:
+        model_path = os.path.join("models", "model.pkl")
+        if not os.path.isfile(model_path):
+            raise ValueError("Model file does not exist.")
+
+    predictions_file_name = (
+        f"predictions_{datetime.now().strftime(DATE_TIME_PATTERN)}.csv"
+    )
+
+    # preprocess inference data
+    c.run(
+        f"python preprocess.py --inference-run True --csv-raw-path {DEFAULT_CSV_RAW_INFERENCE_PATH}"
+    )
+
+    # predict on inference
+    c.run(
+        f"python predict.py --ignore-wandb --input-data-path {DEFAULT_CSV_INFERENCE_PATH} --predictions-only True --predictions-file-name {predictions_file_name}"
+    )
+
+    print("Predict inference finished.")
+
+
+@task(optional=["thr"])
+def compute_metrics(
+    y_true_file_path, y_pred_file_path, thr=COMPUTE_METRICS_DEFAULT_THR
+):
+
+    y_true = pd.read_csv(y_true_file_path, names=["is_click"])
+    y_pred = pd.read_csv(y_pred_file_path, names=["is_click_predicted"])
+
+    print(f"f1: {f1_score(y_true.is_click, y_pred.is_click_predicted > thr)}")
+
+    precision, recall, _ = precision_recall_curve(y_true, y_pred)
+    pr_auc = auc(recall, precision)
+    print(f"PRAUC: {pr_auc}")
 
 
 @task(optional=["name", "base_folder", "leave_data"])
@@ -173,3 +320,34 @@ def archive_experiment(
         os.makedirs("models", exist_ok=True)
 
     print("experiment archived.")
+
+
+@task(optional=["name", "leave_data"])
+def clear_experiment(
+    c,
+    name=UKNOWN_EXPERIMENT_NAME,
+    leave_data=False,
+):
+    print(f"clearing experiment {name}...")
+
+    # Handle data folder
+    if os.path.exists("data"):
+        if not leave_data:
+            for filename in os.listdir("data"):
+                if filename not in [CSV_RAW_TRAIN_FILENAME, CSV_RAW_INFERENCE_FILENAME]:
+                    file_path = os.path.join("data", filename)
+                    os.unlink(file_path)
+
+    # Initialize results folder
+    if os.path.exists("results"):
+        for filename in os.listdir("results"):
+            file_path = os.path.join("results", filename)
+            os.unlink(file_path)
+
+    # Initialize models folder
+    if os.path.exists("models"):
+        for filename in os.listdir("models"):
+            file_path = os.path.join("models", filename)
+            os.unlink(file_path)
+
+    print("experiment cleared.")


### PR DESCRIPTION
an upgrade to tasks.py that includes:
- pipeline: determine whether to archive or delete experiment data at the end of the run, determine whether to make predictions on the inference data at the end of each experiment, ability to run on different seeds of random states for splitting the raw train data
- train_all_train: train model on all training data, support archive/delete experiment and predict/no-predict on inference at the end of the run (see above)
- predict_inference: predict an existing model (in the models folder) on inference data
- compute_metrics: compute f1 score and PRAUC for a given data in the format of the predictions submission